### PR TITLE
New memory usage metrics

### DIFF
--- a/src/main/java/com/metamx/metrics/JvmMonitor.java
+++ b/src/main/java/com/metamx/metrics/JvmMonitor.java
@@ -101,7 +101,6 @@ public class JvmMonitor extends AbstractMonitor
 
   private void emitDirectMemMetrics(ServiceEmitter emitter)
   {
-
     for (BufferPoolMXBean pool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
       final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder()
           .setDimension("bufferpoolName", pool.getName());

--- a/src/main/java/com/metamx/metrics/JvmMonitor.java
+++ b/src/main/java/com/metamx/metrics/JvmMonitor.java
@@ -20,127 +20,24 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceMetricEvent;
-import org.gridkit.lab.jvm.perfdata.JStatData;
-import org.gridkit.lab.jvm.perfdata.JStatData.LongCounter;
-import org.gridkit.lab.jvm.perfdata.JStatData.StringCounter;
-import org.gridkit.lab.jvm.perfdata.JStatData.TickCounter;
-
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
 import java.lang.management.MemoryUsage;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import org.gridkit.lab.jvm.perfdata.JStatData;
+import org.gridkit.lab.jvm.perfdata.JStatData.LongCounter;
+import org.gridkit.lab.jvm.perfdata.JStatData.StringCounter;
+import org.gridkit.lab.jvm.perfdata.JStatData.TickCounter;
 
 public class JvmMonitor extends AbstractMonitor
 {
-  /*
-   * The following GC-related code is partially based on
-   * https://github.com/aragozin/jvm-tools/blob/e0e37692648951440aa1a4ea5046261cb360df70/
-   * sjk-core/src/main/java/org/gridkit/jvmtool/PerfCounterGcCpuUsageMonitor.java
-   */
-
-  private enum GcGeneration
-  {
-    YOUNG(0) {
-      @Override
-      String readableGcName(String name)
-      {
-        switch (name) {
-          case "Copy": return "serial";
-          case "PSScavenge": return "parallel";
-          case "PCopy": return "cms";
-          case "G1 incremental collections": return "g1";
-          default: return name;
-        }
-      }
-    },
-    OLD(1) {
-      @Override
-      String readableGcName(String name)
-      {
-        switch (name) {
-          case "MCS": return "serial";
-          case "PSParallelCompact": return "parallel";
-          case "CMS": return "cms";
-          case "G1 stop-the-world full collections": return "g1";
-          default: return name;
-        }
-      }
-    };
-
-    final int jStatOrder;
-
-    GcGeneration(int jStatOrder)
-    {
-      this.jStatOrder = jStatOrder;
-    }
-
-    abstract String readableGcName(String name);
-  }
-
-  private static class GcCounters
-  {
-    final GcGeneration generation;
-    final LongCounter invocations;
-    final TickCounter cpu;
-    final String readableGcName;
-    long lastInvocations = 0;
-    long lastCpuNanos = 0;
-
-    GcCounters(Map<String, JStatData.Counter<?>> jStatCounters, GcGeneration generation)
-    {
-      this.generation = generation;
-      int jStatOrder = generation.jStatOrder;
-      // Names of counters could also be found at
-      // http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/be698ac28848/
-      // src/share/classes/sun/tools/jstat/resources/jstat_options
-      invocations = (LongCounter) jStatCounters.get(String.format("sun.gc.collector.%d.invocations", jStatOrder));
-      cpu = (TickCounter) jStatCounters.get(String.format("sun.gc.collector.%d.time", jStatOrder));
-      String gcName = ((StringCounter) jStatCounters.get(String.format(
-          "sun.gc.collector.%d.name",
-          jStatOrder
-      ))).getString();
-      readableGcName = generation.readableGcName(gcName);
-    }
-
-    void emitCounters(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder)
-    {
-      metricBuilder.setDimension("gcGen", generation.name().toLowerCase());
-      metricBuilder.setDimension("gcName", readableGcName);
-      emitInvocations(emitter, metricBuilder);
-      emitCpu(emitter, metricBuilder);
-    }
-
-    private void emitInvocations(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder)
-    {
-      long newInvocations = invocations.getLong();
-      emitter.emit(metricBuilder.build("jvm/gc/count", newInvocations - lastInvocations));
-      lastInvocations = newInvocations;
-    }
-
-    private void emitCpu(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder)
-    {
-      long newCpuNanos = cpu.getNanos();
-      emitter.emit(metricBuilder.build("jvm/gc/cpu", newCpuNanos - lastCpuNanos));
-      lastCpuNanos = newCpuNanos;
-    }
-  }
-
-  private final GcCounters youngGcCounters;
-  private final GcCounters oldGcCounters;
-
-  {
-    long currentProcessId = SigarUtil.getCurrentProcessId();
-    // connect to itself
-    JStatData jStatData = JStatData.connect(currentProcessId);
-    Map<String, JStatData.Counter<?>> jStatCounters = jStatData.getAllCounters();
-    youngGcCounters = new GcCounters(jStatCounters, GcGeneration.YOUNG);
-    oldGcCounters = new GcCounters(jStatCounters, GcGeneration.OLD);
-  }
-
-
   private final Map<String, String[]> dimensions;
+
+  private final GcCounters gcCounters = new GcCounters();
 
   public JvmMonitor()
   {
@@ -156,10 +53,23 @@ public class JvmMonitor extends AbstractMonitor
   @Override
   public boolean doMonitor(ServiceEmitter emitter)
   {
+    // jvm/mem
+    emitJvmMemMetrics(emitter);
+
+    // direct memory usage
+    emitDirectMemMetrics(emitter);
+
+    // jvm/gc
+    emitGcMetrics(emitter);
+
+    return true;
+  }
+
+  @Deprecated
+  private void emitJvmMemMetrics(ServiceEmitter emitter)
+  {
     // I have no idea why, but jvm/mem is slightly more than the sum of jvm/pool. Let's just include
     // them both.
-
-    // jvm/mem
     final Map<String, MemoryUsage> usages = ImmutableMap.of(
         "heap",    ManagementFactory.getMemoryMXBean().getHeapMemoryUsage(),
         "nonheap", ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage()
@@ -191,12 +101,11 @@ public class JvmMonitor extends AbstractMonitor
       emitter.emit(builder.build("jvm/pool/used",      usage.getUsed()));
       emitter.emit(builder.build("jvm/pool/init",      usage.getInit()));
     }
+  }
 
-    // jvm/gc
-    emitGcMetrics(youngGcCounters, emitter);
-    emitGcMetrics(oldGcCounters, emitter);
+  private void emitDirectMemMetrics(ServiceEmitter emitter)
+  {
 
-    // direct memory usage
     for (BufferPoolMXBean pool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
       final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder()
           .setDimension("bufferpoolName", pool.getName());
@@ -206,14 +115,165 @@ public class JvmMonitor extends AbstractMonitor
       emitter.emit(builder.build("jvm/bufferpool/used", pool.getMemoryUsed()));
       emitter.emit(builder.build("jvm/bufferpool/count", pool.getCount()));
     }
-
-    return true;
   }
 
-  private void emitGcMetrics(GcCounters gcCounters, ServiceEmitter emitter)
+  private void emitGcMetrics(ServiceEmitter emitter)
   {
-    final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
-    MonitorUtils.addDimensionsToBuilder(builder, dimensions);
-    gcCounters.emitCounters(emitter, builder);
+    gcCounters.emit(emitter, dimensions);
+  }
+
+  /*
+   * The following GC-related code is partially based on
+   * https://github.com/aragozin/jvm-tools/blob/e0e37692648951440aa1a4ea5046261cb360df70/
+   * sjk-core/src/main/java/org/gridkit/jvmtool/PerfCounterGcCpuUsageMonitor.java
+   */
+  private class GcCounters
+  {
+    private List<GcGeneration> generations = new ArrayList<>();
+
+    GcCounters()
+    {
+      long currentProcessId = SigarUtil.getCurrentProcessId();
+      // connect to itself
+      JStatData jStatData = JStatData.connect(currentProcessId);
+      Map<String, JStatData.Counter<?>> jStatCounters = jStatData.getAllCounters();
+
+      generations.add(new GcGeneration(jStatCounters, 0, "young"));
+      generations.add(new GcGeneration(jStatCounters, 1, "old"));
+      // Removed in Java 8 but still actual for previous Java versions
+      if (jStatCounters.containsKey("sun.gc.generation.2.name")) {
+        generations.add(new GcGeneration(jStatCounters, 2, "perm"));
+      }
+    }
+
+    void emit(ServiceEmitter emitter, Map<String, String[]> dimensions)
+    {
+      for (GcGeneration generation : generations) {
+        final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
+        MonitorUtils.addDimensionsToBuilder(builder, dimensions);
+        generation.emit(emitter, builder);
+      }
+    }
+  }
+
+  private class GcGeneration
+  {
+    private String name;
+    private GcGenerationCollector collector = null;
+    private List<GcGenerationSpace> spaces = new ArrayList<>();
+
+    GcGeneration(Map<String, JStatData.Counter<?>> jStatCounters, long genIndex, String name)
+    {
+      this.name = name.toLowerCase();
+
+      long spacesCount = ((JStatData.LongCounter) jStatCounters.get(String.format("sun.gc.generation.%d.spaces", genIndex))).getLong();
+      for (long spaceIndex = 0; spaceIndex < spacesCount; spaceIndex++) {
+        spaces.add(new GcGenerationSpace(jStatCounters, genIndex, spaceIndex));
+      }
+
+      if (jStatCounters.containsKey(String.format("sun.gc.collector.%d.name", genIndex))) {
+        collector = new GcGenerationCollector(jStatCounters, genIndex);
+      }
+    }
+
+    void emit(ServiceEmitter emitter, ServiceMetricEvent.Builder builder)
+    {
+      builder.setDimension("gcGen", name);
+
+      if (collector != null) {
+        collector.emit(emitter, builder);
+      }
+
+      for (GcGenerationSpace space: spaces) {
+        space.emit(emitter, builder);
+      }
+    }
+  }
+
+  private class GcGenerationCollector
+  {
+    private String name;
+    private final LongCounter invocationsCounter;
+    private final TickCounter cpuCounter;
+    private long lastInvocations = 0;
+    private long lastCpuNanos = 0;
+
+    GcGenerationCollector(Map<String, JStatData.Counter<?>> jStatCounters, long genIndex)
+    {
+      String collectorKeyPrefix = String.format("sun.gc.collector.%d", genIndex);
+
+      String nameKey = String.format("%s.name", collectorKeyPrefix);
+      StringCounter nameCounter = (StringCounter) jStatCounters.get(nameKey);
+      name = getReadableName(nameCounter.getString());
+
+      invocationsCounter = (LongCounter) jStatCounters.get(String.format("%s.invocations", collectorKeyPrefix));
+      cpuCounter = (TickCounter) jStatCounters.get(String.format("%s.time", collectorKeyPrefix));
+    }
+
+    void emit(ServiceEmitter emitter, ServiceMetricEvent.Builder builder)
+    {
+      builder.setDimension("gcName", name);
+
+      long newInvocations = invocationsCounter.getLong();
+      emitter.emit(builder.build("jvm/gc/count", newInvocations - lastInvocations));
+      lastInvocations = newInvocations;
+
+      long newCpuNanos = cpuCounter.getNanos();
+      emitter.emit(builder.build("jvm/gc/cpu", newCpuNanos - lastCpuNanos));
+      lastCpuNanos = newCpuNanos;
+    }
+
+    private String getReadableName(String name)
+    {
+      switch (name) {
+        // Young gen
+        case "Copy": return "serial";
+        case "PSScavenge": return "parallel";
+        case "PCopy": return "cms";
+        case "G1 incremental collections": return "g1";
+
+        // Old gen
+        case "MCS": return "serial";
+        case "PSParallelCompact": return "parallel";
+        case "CMS": return "cms";
+        case "G1 stop-the-world full collections": return "g1";
+
+        default: return name;
+      }
+    }
+  }
+
+  private class GcGenerationSpace
+  {
+    private String name;
+
+    private LongCounter maxCounter;
+    private LongCounter capacityCounter;
+    private LongCounter usedCounter;
+    private LongCounter initCounter;
+
+    GcGenerationSpace(Map<String, JStatData.Counter<?>> jStatCounters, long genIndex, long spaceIndex)
+    {
+      String spaceKeyPrefix = String.format("sun.gc.generation.%d.space.%d", genIndex, spaceIndex);
+
+      String nameKey = String.format("%s.name", spaceKeyPrefix);
+      StringCounter nameCounter = (StringCounter) jStatCounters.get(nameKey);
+      name = nameCounter.toString().toLowerCase();
+
+      maxCounter      = (LongCounter) jStatCounters.get(String.format("%s.maxCapacity",  spaceKeyPrefix));
+      capacityCounter = (LongCounter) jStatCounters.get(String.format("%s.capacity",     spaceKeyPrefix));
+      usedCounter     = (LongCounter) jStatCounters.get(String.format("%s.used",         spaceKeyPrefix));
+      initCounter     = (LongCounter) jStatCounters.get(String.format("%s.initCapacity", spaceKeyPrefix));
+    }
+
+    void emit(ServiceEmitter emitter, ServiceMetricEvent.Builder builder)
+    {
+      builder.setDimension("gcGenSpaceName", name);
+
+      emitter.emit(builder.build("jvm/gc/mem/max",      maxCounter.getLong()));
+      emitter.emit(builder.build("jvm/gc/mem/capacity", capacityCounter.getLong()));
+      emitter.emit(builder.build("jvm/gc/mem/used",     usedCounter.getLong()));
+      emitter.emit(builder.build("jvm/gc/mem/init",     initCounter.getLong()));
+    }
   }
 }

--- a/src/test/java/com/metamx/metrics/JvmMonitorTest.java
+++ b/src/test/java/com/metamx/metrics/JvmMonitorTest.java
@@ -20,6 +20,7 @@ import com.metamx.emitter.core.Emitter;
 import com.metamx.emitter.core.Event;
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceMetricEvent;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -75,7 +76,12 @@ public class JvmMonitorTest
     public void emit(Event e)
     {
       ServiceMetricEvent event = (ServiceMetricEvent) e;
-      switch (event.getMetric() + "/" + event.toMap().get("gcGen")) {
+      String gcGen = null;
+      if (event.toMap().get("gcGen") != null) {
+        gcGen = ((List) event.toMap().get("gcGen")).get(0).toString();
+      }
+
+      switch (event.getMetric() + "/" + gcGen) {
         case "jvm/gc/count/old":
           oldGcCount = event.getValue();
           break;


### PR DESCRIPTION
Currently, we emit pool memory usage for next pool names:

Heap pools:
- G1 Eden Space
- G1 Survivor Space
- G1 Old Gen
- CMS Old Gen
- Par Eden Space
- Par Survivor Space
- PS Eden Space
- PS Old Gen
- PS Survivor Space

Non-heap pools:
- PS Perm Gen
- G1 Perm Gen
- CMS Perm Gen
- Metaspace
- Compressed Class Space
- Code Cache

For the same generation current implementation emits different pool names for different GC, and also we don't have any possibility to easily group spaces by generation (for example eden and survivor spaces belong to young generation).

Suggested metrics closer describing Java memory model (for example for young generation 3 different spaces will be emitted: eden, s0, s1). But new metrics don't have any non-heap memory usage metrics (except perm gen, which has been removed in Java 8).

I kept old metrics but marked them as `@Deprecated` and we can remove them in future releases.