### PR TITLE
Make sigar optional again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
             <groupId>org.hyperic</groupId>
             <artifactId>sigar</artifactId>
             <version>${sigar.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.hyperic</groupId>


### PR DESCRIPTION
Without `optional` for sigar dependency we have to specify repository for sigar library even if we don't use sigar or even if it another library which depends on server-metrics